### PR TITLE
Change actor tests for requirement 9.2.0.0-* to only apply to cmi5 defined statements.

### DIFF
--- a/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
+++ b/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
@@ -427,6 +427,9 @@ const saveLearnerPrefs = async (
                 type: "passed",
                 alter: (st) => {
                     st.actor.objectType = "Unknown";
+                },
+                cfg: {
+                    expectedStatuses: [400, 403]
                 }
             },
             {

--- a/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
+++ b/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
@@ -414,22 +414,25 @@ const saveLearnerPrefs = async (
                 }
             },
             {
-                // statement with actor objectType set to "Group"
+                // defined statement with actor objectType set to "Group"
                 reqId: "9.2.0.0-2",
+                type: "passed",
                 alter: (st) => {
                     st.actor.objectType = "Group";
                 }
             },
             {
-                // statement with actor objectType set to an invalid value
+                // defined statement with actor objectType set to an invalid value
                 reqId: "9.2.0.0-2",
+                type: "passed",
                 alter: (st) => {
                     st.actor.objectType = "Unknown";
                 }
             },
             {
-                // statement with actor using an mbox IFI instead of account
+                // defined statement with actor using an mbox IFI instead of account
                 reqId: "9.2.0.0-3",
+                type: "passed",
                 alter: (st) => {
                     delete st.actor.account;
                     st.actor.mbox = "mailto:catapult@example.com";

--- a/lts/pkg/src/lib/helpers.js
+++ b/lts/pkg/src/lib/helpers.js
@@ -147,6 +147,17 @@ const Helpers = {
                 console.log(reqId, stContent);
             }
 
+            // If we provide an explicit set of statuses to match, exclude fallthrough cases.
+            if (cfg.expectedStatuses) {
+                if (cfg.expectedStatuses.indexOf(stResponse.status) > -1) {
+                    return true;
+                }
+
+                Helpers.storeResult(false, false, {reqId, msg: `Statement should have been rejected with a status code of (one of) ${cfg.expectedStatuses}, received response status code: ${stResponse.status} ${stContent} (Testing ${reqId})`});
+
+                return false;
+            }
+
             if (stResponse.status === 204 || stResponse.status === 200) {
                 Helpers.storeResult(false, false, {reqId, msg: `Statement not rejected (${stResponse.status})`});
 


### PR DESCRIPTION
Addressing https://rusticisoftware.slack.com/archives/C025TQVHG/p1640101691047000

We were incorrectly testing 9.2.0.0 requirements against cmi5 allowed statements, since that section specifically only applies to cmi5 defined statements.  This uses a cmi5 defined statement for the actor corruption tests.