### PR TITLE
Split status code 400/401/403 responses in various places

### DIFF
--- a/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
+++ b/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
@@ -98,17 +98,17 @@ const saveLearnerPrefs = async (
 
                 return false;
             }
-            // this treats non-401 and non-403 (like 400, 500, etc.) as not acceptable responses
+            // this treats non-403 (like 400, 500, etc.) as not acceptable responses
             // for denying the request
             // eslint-disable-next-line no-magic-numbers
-            else if (response.status !== 401 && response.status !== 403) {
+            else if (response.status !== 403) {
                 Helpers.storeResult(false, false, {reqId: "4.2.0.0-2", msg: `Save learner preferences response status code: ${response.status} ${responseContent} (Testing ${reqId})`});
 
                 return false;
             }
         }
         catch (ex) {
-            // request should succeed, but provide a 401 or 403, so an exception here is an error
+            // request should succeed but provide a 403, so an exception here is an error
             Helpers.storeResult(false, true, {reqId, msg: `Failed request to save learner preferences: ${ex}`});
 
             return false;
@@ -135,7 +135,7 @@ const saveLearnerPrefs = async (
         // send statement prior to getting auth token, with value
         //
         cmi5.setAuth("Basic Y2F0YXB1bHQ6ZmlyZSBzb21lIFJ1c3RpY2kgU29mdHdhcmUgcm9ja3Mh");
-        if (! await Helpers.sendStatement(cmi5, preInitializedSt, "8.1.2.0-2 (d)")) {
+        if (! await Helpers.sendStatement(cmi5, preInitializedSt, "8.1.2.0-2 (d)", {shouldSucceed: false, acceptUnauthorized: true})) {
             return;
         }
 
@@ -330,7 +330,7 @@ const saveLearnerPrefs = async (
         const origAuth = cmi5.getAuth();
 
         cmi5.setAuth("");
-        if (! await Helpers.sendStatement(cmi5, preInitializedSt, "8.1.2.0-5 (d)")) {
+        if (! await Helpers.sendStatement(cmi5, preInitializedSt, "8.1.2.0-5 (d)", {shouldSucceed: false, acceptUnauthorized: true})) {
             return;
         }
 
@@ -798,7 +798,7 @@ const saveLearnerPrefs = async (
             return;
         }
 
-        Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with either 401 or 403 response status"});
+        Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with 403 response status"});
     };
     /* eslint-enable padding-line-between-statements */
 

--- a/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
+++ b/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
@@ -98,7 +98,15 @@ const saveLearnerPrefs = async (
 
                 return false;
             }
-            // this treats non-403 (like 400, 500, etc.) as not acceptable responses
+            // If no actor is provided to an agent profile endpoint, xAPI rules apply and requires a 400, not a 403.
+            else if (noActor) {
+                if (response.status !== 400) {
+                    Helpers.storeResult(false, false, {reqId, msg: `Save learner preferences with no actor query param should have responded with a status code: 400, but instead had a response status code: ${response.status} ${responseContent} (Testing ${reqId})`});
+
+                    return false;
+                }
+            }
+            // this treats other non-403 (like 400, 500, etc.) as not acceptable responses
             // for denying the request
             // eslint-disable-next-line no-magic-numbers
             else if (response.status !== 403) {

--- a/lts/pkg/src/005-2-invalid-au/005-2-invalid-au.js
+++ b/lts/pkg/src/005-2-invalid-au/005-2-invalid-au.js
@@ -71,7 +71,7 @@ const execute = async () => {
 
     await Helpers.closeAU(cmi5);
 
-    Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with either 401 or 403 response status"});
+    Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with 403 response status"});
 };
 
 execute();

--- a/lts/pkg/src/006-launchMode/006-launchMode.js
+++ b/lts/pkg/src/006-launchMode/006-launchMode.js
@@ -49,7 +49,7 @@ const execute = async () => {
         return;
     }
 
-    Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with either 401 or 403 response status"});
+    Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with 403 response status"});
 
     await Helpers.closeAU(cmi5);
 };

--- a/lts/pkg/src/007-1-multi-session/007-1-multi-session.js
+++ b/lts/pkg/src/007-1-multi-session/007-1-multi-session.js
@@ -54,7 +54,7 @@ const execute = async () => {
             return;
         }
 
-        Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with either 401 or 403 response status"});
+        Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with 403 response status"});
     }
 
     await Helpers.closeAU(cmi5);

--- a/lts/pkg/src/007-2-multi-session/007-2-multi-session.js
+++ b/lts/pkg/src/007-2-multi-session/007-2-multi-session.js
@@ -61,7 +61,7 @@ const execute = async () => {
 
         await Helpers.closeAU(cmi5);
 
-        Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with either 401 or 403 response status"});
+        Helpers.storeResult(true, false, {msg: "LMS rejected set of statements with 403 response status"});
     }
 };
 

--- a/lts/pkg/src/lib/helpers.js
+++ b/lts/pkg/src/lib/helpers.js
@@ -152,17 +152,22 @@ const Helpers = {
 
                 return false;
             }
-            // this treats non-401 and non-403 (like 400, 500, etc.) as not acceptable responses
+            // treats specific tests for unauthorized requests as acceptable responses.
+            // eslint-disable-next-line no-magic-numbers
+            else if (stResponse.status === 401 && cfg.acceptUnauthorized) {
+                return true;
+            }
+            // this treats non-403 (like 400, 500, etc.) as not acceptable responses
             // for denying the statement
             // eslint-disable-next-line no-magic-numbers
-            else if (stResponse.status !== 401 && stResponse.status !== 403) {
+            else if (stResponse.status !== 403) {
                 Helpers.storeResult(false, false, {reqId: "4.2.0.0-2", msg: `Statement request status code: ${stResponse.status} ${stContent} (Testing ${reqId})`});
 
                 return false;
             }
         }
         catch (ex) {
-            // request should succeed, but provide a 401 or 403, so an exception here is an error
+            // request should succeed so an exception here is an error
             Helpers.storeResult(false, true, {reqId, msg: `Failed request to store statement: ${ex}`});
 
             return false;

--- a/player/service/plugins/routes/lrs.js
+++ b/player/service/plugins/routes/lrs.js
@@ -388,6 +388,9 @@ const Boom = require("@hapi/boom"),
         }
         else if (resource === "agents") {
             // all agents requests require an actor, and that actor must be the launch actor
+
+            let parsedAgent;
+
             try {
                 parsedAgent = JSON.parse(req.query.agent);
             }
@@ -400,7 +403,7 @@ const Boom = require("@hapi/boom"),
         else if (resource === "agents/profile") {
             // all agents/profile requests require an actor,
             if (typeof req.query.agent === "undefined") {
-                throw Helpers.buildViolatedReqId("11.0.0.0-1", "'agent' parameter missing");
+                throw Helpers.buildViolatedReqId("11.0.0.0-1", "'agent' parameter missing", "badRequest");
             }
 
             let parsedAgent;


### PR DESCRIPTION
This addresses situations where 401s and 400s were masked by 403s, including https://rusticisoftware.slack.com/archives/C025TQVHG/p1639414487462100 .  Agent profiles should now return 400s on missing agents, 401s should occur when requests use invalid credentials intentionally and tests should still pass.  403s preserved for most other cmi5-related data validation cases.