### PR TITLE
allow 401 after session terminated

### DIFF
--- a/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
+++ b/lts/pkg/src/005-1-invalid-au/005-1-invalid-au.js
@@ -774,7 +774,7 @@ const saveLearnerPrefs = async (
         // send statement after terminated
         // Also validates: 9.3.0.0-2 (d)
         //
-        if (! await Helpers.sendStatement(cmi5, allowedSt, "9.3.0.0-5 (d2)")) {
+        if (! await Helpers.sendStatement(cmi5, allowedSt, "9.3.0.0-5 (d2)", {shouldSucceed: false, acceptUnauthorized: true})) {
             return;
         }
 


### PR DESCRIPTION
This test expects `403`, however it's reasonable to delete the session upon termination, so `401` should also be allowed